### PR TITLE
Fix a spellig mistake and fix the ambiguous license

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ bash.org quote viewer
 
 Browse quotes on bash.org from the comfort of your shell.
 
-* Free software: BSD license
+* License: BSD 3-Clause License
 * Documentation: http://bash_quote.rtfd.org.
 
 Installation

--- a/bash_quote/bash_quote.py
+++ b/bash_quote/bash_quote.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 '''\
-Browse bash.org from the comfort fo your shell.\
+Browse bash.org from the comfort of your shell.\
 '''
 
 


### PR DESCRIPTION
I'm using a slightly a modified of your program for a Telegram bot and I noticed these small issues.

The issue with calling it "the BSD license" is that there are three BSD licenses. The Simplified BSD license, the New/3-Clause/Revised BSD License and the ISC License. [1]

There are few differences between these so it's important to name exactly which one you're using.

[1] http://choosealicense.com/licenses/
